### PR TITLE
[WebExtensions] Update node about menus.create() contexts option

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.md
@@ -51,8 +51,8 @@ browser.menus.create(
 
     - `contexts` {{optional_inline}}
       - : `array` of {{WebExtAPIRef('menus.ContextType')}}. Array of contexts in which this menu item will appear. If this option is omitted:
-        - if the item's parent has contexts set, then this item will inherit its parent's contexts
-        - otherwise, the item is given a context array of \["page"].
+        - in Chrome, this menu will get context array of \["page"].
+        - in Firefox, if the item has parent specified by `parentId` which has contexts set, then this item will inherit its parent's contexts. Otherwise, the item is given a context array of \["page"].
 
     - `documentUrlPatterns` {{optional_inline}}
       - : `array` of `string`. Lets you restrict the item to apply only to documents whose URL matches one of the given [match patterns](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns). This applies to frames as well.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Add a note describing Firefox and Chrome behavior if call to `menus.create()` omits `contexts` option.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Describe Firefox and Chrome inconsistency.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
Tested via the following:
 - Create extension creating three options:
   - `id` set to `"parent"` and `contexts` set to `['editable']`
   - `id` set to `"child-no-contexts"` and `parentId` set to `'parent'` and `contexts` omitted
   - `id` set to `"child-with-contexts"` and `parentId` set to `'parent'` and `contexts` set to `['editable']`
 - Open a page with `<editable>` element
 - Right-chick the `<editable>` element and observe context menu

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
